### PR TITLE
Add ruff as replacement to flake8

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 * [Shellharden](https://github.com/anordal/shellharden) - The corrective bash syntax highlighter
 
+#### [Flake8](https://flake8.pycqa.org/)
+
+* [ruff](https://beta.ruff.rs/docs/) - lint and fix 40x faster than flake8
+
 ## Libraries
 
 ### Email

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 #### [Flake8](https://github.com/PyCQA/flake8)
 
-* [ruff](https://beta.ruff.rs/docs/) - lint and fix 40x faster than flake8
+* [ruff](https://github.com/astral-sh/ruff) - lint and fix 40x faster than flake8
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 * [deno](https://github.com/denoland/deno) - A secure JavaScript and TypeScript runtime 
 
-#### [Flake8](https://flake8.pycqa.org/)
+#### [Flake8](https://github.com/PyCQA/flake8)
 
 * [ruff](https://beta.ruff.rs/docs/) - lint and fix 40x faster than flake8
 


### PR DESCRIPTION
Thank you for making awesome-alternatives-in-rust better!

Here's a checklist for things that will be checked during review or continuous integration.

- \[ ] `cargo run` passes locally.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
