### PR TITLE
adds helix and wezterm to their correspondent sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### [termite](https://github.com/thestinger/termite)
 
 * [Alacritty](https://github.com/alacritty/alacritty) - A cross-platform, OpenGL terminal emulator.
+* [WezTerm](https://wezfurlong.org/wezterm/index.html) - Powerful cross-platform terminal emulator and multiplexer implemented in Rust.
 
 #### [tmux](https://github.com/tmux/tmux)
 
@@ -213,6 +214,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### Vim
 
 * [Amp](https://github.com/jmacdonald/amp) - A complete text editor for your terminal.
+* [Helix](https://helix-editor.com) - A post-modern text editor based on VIM (but with fundamental differences).
 
 ### Text processing
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If you want to contribute, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 #### [termite](https://github.com/thestinger/termite)
 
 * [Alacritty](https://github.com/alacritty/alacritty) - A cross-platform, OpenGL terminal emulator.
-* [WezTerm](https://wezfurlong.org/wezterm/index.html) - Powerful cross-platform terminal emulator and multiplexer implemented in Rust.
+* [WezTerm](https://github.com/wez/wezterm) - A GPU-accelerated cross-platform terminal emulator and multiplexer.
 
 #### [tmux](https://github.com/tmux/tmux)
 


### PR DESCRIPTION
Thank you for making awesome-alternatives-in-rust better!

Here's a checklist for things that will be checked during review or continuous integration.

- \[ ] `cargo run` passes locally.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
