### PR TITLE
Add ATG as replacement for gtfToGenePred

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 
 * [fastmod](https://github.com/facebookincubator/fastmod) - A fast partial replacement for the codemod tool
 
+#### [gtfToGenePred/genePredToGtf](https://hgdownload.soe.ucsc.edu/downloads.html#utilities_downloads)
+
+* [atg](https://github.com/anergictcell/atg) - Parse, check and convert genomic data file formats
+
 #### [jq](https://github.com/jqlang/jq)
 
 * [jql](https://github.com/yamafaktory/jql) - A JSON Query Language CLI tool built with Rust 🦀


### PR DESCRIPTION
Thank you for making awesome-alternatives-in-rust better!

Here's a checklist for things that will be checked during review or continuous integration.

- \[ ] `cargo run` passes locally.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
