### PR TITLE
Add `dqy` alternative to `dig`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ I renamed the repository to "Awesome Alternatives in Rust". The original name wa
 #### dig
 
 * [dog](https://github.com/ogham/dog) - A command-line DNS client.
+* [dqy](https://github.com/dandyvica/dqy) - A DNS query tool inspired by `dig`, `drill`, and `dog`.
 
 #### du
 


### PR DESCRIPTION
Thank you for making awesome-alternatives-in-rust better!

Here's a checklist for things that will be checked during review or continuous integration.

- \[ ] `cargo run` passes locally.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
